### PR TITLE
Add more generate climos support

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -244,6 +244,24 @@ class CFDataset(Dataset):
         return bool(self.climatology_bounds_var_name)
 
     @property
+    def lat_var(self):
+        """The latitude variable (netCDF4.Variable) in this file"""
+        axes = self.dim_axes_from_names()
+        try:
+            return self.variables[axes['Y']]
+        except KeyError:
+            raise ValueError('No axis is attributed with latitude information')
+
+    @property
+    def lon_var(self):
+        """The longitude variable (netCDF4.Variable) in this file"""
+        axes = self.dim_axes_from_names()
+        try:
+            return self.variables[axes['X']]
+        except KeyError:
+            raise ValueError('No axis is attributed with longitude information')
+
+    @property
     def time_var(self):
         """The time variable (netCDF4.Variable) in this file"""
         axes = self.dim_axes_from_names()

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -514,10 +514,16 @@ class CFDataset(Dataset):
             return template.format(r=self.realization,
                                    i=self.initialization_method,
                                    p=self.physics_version)
-        else:
+        elif self.is_downscaled_output:
             return template.format(r=self.driving_realization,
                                    i=self.driving_initialization_method,
                                    p=self.driving_physics_version)
+        elif self.is_hydromodel_dgcm_output:
+            return template.format(r=self.forcing_driving_realization,
+                                   i=self.forcing_driving_initialization_method,
+                                   p=self.forcing_driving_physics_version)
+        elif self.is_hydromodel_iobs_output:
+            raise NotImplementedError
 
     def _cmor_type_filename_components(self, tres_to_mip_table=standard_tres_to_mip_table, **override):
         """Return a dict containing appropriate arguments to function cmor_type_filename (q.v.),
@@ -568,8 +574,8 @@ class CFDataset(Dataset):
         elif self.is_hydromodel_dgcm_output:
             components.update(
                 hydromodel_method=_replace_commas(self.hydromodel_method_id),
-                model=self.driving_model_id,
-                experiment=_replace_commas(self.driving_experiment_id),
+                model=self.forcing_driving_model_id,
+                experiment=_replace_commas(self.forcing_driving_experiment_id),
                 geo_info=getattr(self, 'domain', None)
             )
         elif self.is_hydromodel_iobs_output:

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -95,7 +95,7 @@ def _cmor_formatted_time_range(t_min, t_max, time_resolution='daily'):
     return '{}-{}'.format(t_min.strftime(format), t_max.strftime(format))
 
 
-def _handle_indirection(value):
+def _indirection_info(value):
     """Return (True, <property name>) iff ``value`` is a string that indirects to another property value.
     Otherwise return (False, None).
     See CFDataset docstring for explanation of indirect values.
@@ -175,7 +175,7 @@ class CFDataset(Dataset):
         """Return True iff the property named has an indirect value.
         See class docstring for explanation of indirect values.
         """
-        return _handle_indirection(self.get_direct_value(name))[0]
+        return _indirection_info(self.get_direct_value(name))[0]
 
     def get_direct_value(self, name):
         """Return the value of the named property without indirection processing.
@@ -191,7 +191,7 @@ class CFDataset(Dataset):
         :param name: (str) name of attribute
         """
         value = super(CFDataset, self).__getattribute__(name)  # cannot use ``getattr``, otherwise infinite recursion
-        is_indirected, indirected_property = _handle_indirection(value)
+        is_indirected, indirected_property = _indirection_info(value)
         if is_indirected:
             # The condition for retrieving the value of an indirected property is
             #   ``is_indirected`` and <the property named by ``indirected_property`` exists>

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -486,14 +486,13 @@ class CFDataset(Dataset):
 
     @property
     def is_hydromodel_dgcm_output(self):
-        """True iff the content of the file is output of a hydrological model driven by downscaled GCM data."""
-        return self.is_hydromodel_output and hasattr(self, 'downscaling_method_id') and hasattr(self, 'driving_model_id')
+        """True iff the content of the file is output of a hydrological model forced by downscaled GCM data."""
+        return self.is_hydromodel_output and self.forcing_type == 'downscaled gcm'
 
     @property
     def is_hydromodel_iobs_output(self):
-        """True iff the content of the file is output of a hydrological model driven by interpolated observational data."""
-        raise NotImplementedError
-        return self.is_hydromodel_output # TODO: additional conditions
+        """True iff the content of the file is output of a hydrological model forced by interpolated observational data."""
+        return self.is_hydromodel_output and self.forcing_type == 'gridded observations'
 
     @property
     def climo_periods(self):

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -50,6 +50,7 @@ def cmor_type_filename(extension='', **component_values):
         model
         experiment
         ensemble_member
+        obs_dataset_id
         time_range
         geo_info
     '''.split()
@@ -523,7 +524,9 @@ class CFDataset(Dataset):
                                    i=self.forcing_driving_initialization_method,
                                    p=self.forcing_driving_physics_version)
         elif self.is_hydromodel_iobs_output:
-            raise NotImplementedError
+            raise ValueError('ensemble_member has no meaning for a hydrological model forced by observational data')
+        else:
+            raise ValueError('cannot generate ensemble_member for a file without a recognized type')
 
     def _cmor_type_filename_components(self, tres_to_mip_table=standard_tres_to_mip_table, **override):
         """Return a dict containing appropriate arguments to function cmor_type_filename (q.v.),
@@ -579,12 +582,11 @@ class CFDataset(Dataset):
                 geo_info=getattr(self, 'domain', None)
             )
         elif self.is_hydromodel_iobs_output:
-            raise NotImplementedError
-            # TODO: props for observational data info
-            # components.update(
-            #     hydromodel_method=_join_comma_separated_list(self.hydromodel_method_id),
-            #     geo_info=getattr(self, 'domain', None)
-            # )
+            components.update(
+                hydromodel_method=_replace_commas(self.hydromodel_method_id),
+                obs_dataset_id=self.forcing_obs_dataset_id,
+                geo_info=getattr(self, 'domain', None)
+            )
 
         # Override with supplied args
         components.update(**override)

--- a/nchelpers/decorators.py
+++ b/nchelpers/decorators.py
@@ -1,0 +1,29 @@
+from functools import wraps
+from threading import local
+
+
+def prevent_infinite_recursion(func):
+    """Decorator that detects infinite recursion of a function and raises an exception if so.
+    Adopted from http://stackoverflow.com/a/15955706.
+    Thread-safe. Function arguments must be hashable.
+    """
+    func._thread_locals = local()
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        params = tuple(args) + tuple(kwargs.items())
+
+        if not hasattr(func._thread_locals, 'seen'):
+            func._thread_locals.seen = set()
+        if params in func._thread_locals.seen:
+            raise RuntimeError('Already called {} with the same arguments'.format(func.__name__))
+
+        func._thread_locals.seen.add(params)
+        try:
+            res = func(*args, **kwargs)
+        finally:
+            func._thread_locals.seen.remove(params)
+
+        return res
+
+    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,16 @@
-import pytest
-from pytest import fixture, mark
+from pytest import fixture
 from pkg_resources import resource_filename
 from nchelpers import CFDataset
 
 
 @fixture
 def tiny_dataset(request):
+    """Return a 'tiny' test dataset, based on request param.
+
+    request.param: (str) selects the test file to be returned
+    returns: (nchelpers.CFDataset) test file as a CFDataset object
+
+    This fixture should be invoked with indirection.
+    """
     filename = 'data/tiny_{}.nc'.format(request.param)
     return CFDataset(resource_filename('nchelpers', filename))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,21 @@ def tiny_dataset(request):
     """
     filename = 'data/tiny_{}.nc'.format(request.param)
     return CFDataset(resource_filename('nchelpers', filename))
+
+
+@fixture
+def indir_dataset(tmpdir):
+    fp = tmpdir.join('fake.nc')
+    with CFDataset(fp, mode='w') as cf:
+        # ordinary values
+        cf.one = 1
+        cf.two = 2
+        # indirect values
+        cf.uno = '@one'  # one level
+        cf.un = '@uno'   # two levels
+        # circular indirection
+        cf.foo = '@bar'
+        cf.bar = '@foo'
+        # indirect without corresponding property
+        cf.baz = '@qux'
+        yield cf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ def tiny_dataset(request):
 
 @fixture
 def indir_dataset(tmpdir):
-    fp = tmpdir.join('fake.nc')
+    """Yield an otherwise empty netCDF file containing some indirected attributes for testing."""
+    fp = tmpdir.join('indirect_test.nc')
     with CFDataset(fp, mode='w') as cf:
         # ordinary values
         cf.one = 1

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -21,8 +21,7 @@ from nchelpers.date_utils import time_to_seconds
 # TODO: Get a real GCM-driven hydromodel output file and adjust tiny_hydromodel_gcm.nc and its tests as necessary
 
 # TODO: Create an observation-driven hydromodel output file and use it to create tiny_hydromodel_obs.nc and tests
-# This will follow settling of metadata standard for obs-driven hydromodel output with assistance from Arelia week
-# of Mar 20
+# Arelia is preparing such a file as of Apr 4.
 
 # Test CFDataset properties that can be tested with a simple equality test. Most are of this kind.
 @mark.parametrize('tiny_dataset, prop, expected', [

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -8,7 +8,10 @@
 The data in these files is very limited spatially and temporally (though valid) in order to reduce their size,
 and their global metadata is standard.
 
-All tests are parameterized over these files, usually via the indirect fixture object `tiny_dataset`.
+All tests are parameterized over these files, which requires a little trickiness with fixtures.
+pytest doesn't directly support parametrizing over fixtures (which here delivers the test input file)
+To get around that, we use indirect fixtures, which are passed a parameter
+that they use to determine their behaviour, i.e. what input file to return.
 """
 from datetime import datetime
 from pytest import mark

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -198,8 +198,13 @@ def test_dependent_varnames(tiny_dataset, expected):
     'hydromodel_gcm',
     'climo_gcm',
 ], indirect=True)
-def test_time_var(tiny_dataset):
-    assert tiny_dataset.time_var.standard_name == 'time'
+@mark.parametrize('property, standard_name', [
+    ('time_var', 'time'),
+    ('lon_var', 'longitude'),
+    ('lat_var', 'latitude'),
+])
+def test_common_vars(tiny_dataset, property, standard_name):
+    assert getattr(tiny_dataset, property).standard_name == standard_name
 
 
 @mark.parametrize('tiny_dataset, start_time, end_time', [


### PR DESCRIPTION
Updates to accommodate PCIC metadata standard changes and downstream implications of it for climate-explorer-backend data prep, which in turn this repo supports. Specifically:

- properties `lat_var` and `lon_var`
- support for indirect values of attributes
- recognition and filename generation for hydromodels forced by downscaled gcm and by gridded obs 