### PR TITLE
Updates to support modelmeta/index_netcdf

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -537,6 +537,19 @@ class CFDataset(Dataset):
         return self.is_hydromodel_output and self.forcing_type == 'gridded observations'
 
     @property
+    def model_type(self):
+        """String indicating what type of model the file contains.
+        Supports modelmeta/mm_cataloguer/index_netcdf.py.
+        Really rudimentary decision making about model type.
+        """
+        if self.metadata.project == 'NARCCAP' or \
+                        self.metadata.project not in ('IPCC Fourth Assessment', 'CMIP5'):
+            return 'RCM'
+        else:
+            return 'GCM'
+
+
+    @property
     def climo_periods(self):
         """List of the standard climatological periods (see function standard_climo_periods)
         that are a subset of the date range in the file."""

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -23,6 +23,8 @@ from nchelpers.date_utils import time_to_seconds
 # TODO: Create an observation-driven hydromodel output file and use it to create tiny_hydromodel_obs.nc and tests
 # Arelia is preparing such a file as of Apr 4.
 
+# TODO: Get an RCM output file and test against it. (Driven by property 'model_type'.)
+
 # Test CFDataset properties that can be tested with a simple equality test. Most are of this kind.
 @mark.parametrize('tiny_dataset, prop, expected', [
     ('gcm', 'first_MiB_md5sum', b'>\xb8\x12\xcc\xa96is\xb4\x10x\xb0\xbf\x19\xfe;'),
@@ -37,6 +39,7 @@ from nchelpers.date_utils import time_to_seconds
     ('gcm', 'is_hydromodel_output', False),
     ('gcm', 'is_hydromodel_dgcm_output', False),
     # ('gcm', 'is_hydromodel_iobs_output', False), # TODO
+    ('gcm', 'model_type', 'GCM'),
     ('gcm', 'ensemble_member', 'r1i1p1'),
     ('gcm', 'cmor_filename', 'tasmax_day_BNU-ESM_historical_r1i1p1_19650101-19750101.nc'),
     ('gcm', 'unique_id', 'tasmax_day_BNU-ESM_historical_r1i1p1_19650101-19750101'),
@@ -53,6 +56,7 @@ from nchelpers.date_utils import time_to_seconds
     ('downscaled', 'is_hydromodel_output', False),
     ('downscaled', 'is_hydromodel_dgcm_output', False),
     # ('downscaled', 'is_hydromodel_iobs_output', False), # TODO
+    ('downscaled', 'model_type', 'GCM'),
     ('downscaled', 'ensemble_member', 'r1i1p1'),
     ('downscaled', 'cmor_filename', 'tasmax_day_BCCAQ2_ACCESS1-0_historical+rcp45_r1i1p1_19600101-19911231.nc'),
     ('downscaled', 'unique_id', 'tasmax_day_BCCAQ2_ACCESS1-0_historical-rcp45_r1i1p1_19600101-19911231'),
@@ -69,6 +73,7 @@ from nchelpers.date_utils import time_to_seconds
     ('hydromodel_gcm', 'is_hydromodel_output', True),
     ('hydromodel_gcm', 'is_hydromodel_dgcm_output', True),
     # ('hydromodel_gcm', 'is_hydromodel_iobs_output', False), # TODO
+    ('hydromodel_gcm', 'model_type', 'GCM'),
     ('hydromodel_gcm', 'ensemble_member', 'r1i1p1'),
     ('hydromodel_gcm', 'cmor_filename',
      'BASEFLOW+EVAP+GLAC_AREA_BAND+GLAC_MBAL_BAND+RUNOFF+SWE_BAND_day_VICGL+RGM+HydroCon_ACCESS1-0_historical+rcp45_r1i1p1_19840101-19951231.nc'),
@@ -89,6 +94,7 @@ from nchelpers.date_utils import time_to_seconds
     ('climo_gcm', 'is_hydromodel_output', False),
     ('climo_gcm', 'is_hydromodel_dgcm_output', False),
     # ('climo_gcm', 'is_hydromodel_iobs_output', False), # TODO
+    ('climo_gcm', 'model_type', 'GCM'),
     ('climo_gcm', 'cmor_filename', 'tasmax_msaClim_BNU-ESM_historical_r1i1p1_19650101-19701230.nc'),
     ('climo_gcm', 'unique_id', 'tasmax_msaClim_BNU-ESM_historical_r1i1p1_19650101-19701230'),
 ], indirect=['tiny_dataset'])

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -192,6 +192,10 @@ def test_axes_dim(tiny_dataset, expected):
     assert tiny_dataset.axes_dim() == expected
 
 
+# TODO: Obtain a test file with reduced dimensions and test reduced_dims with it.
+# Request sent to Stephen Sobie and Trevor Murdock 2017-06-02 for such a file.
+
+
 @mark.parametrize('tiny_dataset, expected', [
     ('gcm', {'tasmax'}),
     ('downscaled', {'tasmax'}),

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -137,8 +137,8 @@ def test_dim_names(tiny_dataset, expected):
     'climo_gcm',
 ], indirect=True)
 @mark.parametrize('dim_name, expected', [
-    (['time'], {'T': 'time'}),
-    (['time', 'lon'], {'T': 'time', 'X': 'lon'}),
+    (['time'], {'time': 'T'}),
+    (['time', 'lon'], {'time': 'T', 'lon': 'X'}),
 ])
 def test_dim_axes_from_names(tiny_dataset, dim_name, expected):
     assert tiny_dataset.dim_axes_from_names(dim_name) == expected
@@ -146,10 +146,10 @@ def test_dim_axes_from_names(tiny_dataset, dim_name, expected):
 
 # Tests for all dimensions - may differ between datasets.
 @mark.parametrize('tiny_dataset, expected', [
-    ('gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
-    ('downscaled', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
-    ('hydromodel_gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),  # why isn't depth in this list?
-    ('climo_gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
+    ('gcm', {'time': 'T', 'lon': 'X', 'lat': 'Y'}),
+    ('downscaled', {'time': 'T', 'lon': 'X', 'lat': 'Y'}),
+    ('hydromodel_gcm', {'time': 'T', 'lon': 'X', 'lat': 'Y'}),  # why isn't depth in this list?
+    ('climo_gcm', {'time': 'T', 'lon': 'X', 'lat': 'Y'}),
 ], indirect=['tiny_dataset'])
 def test_dim_axes_from_names2(tiny_dataset, expected):
     assert tiny_dataset.dim_axes_from_names() == expected
@@ -179,6 +179,17 @@ def test_dim_axes(tiny_dataset, dim_name, expected):
 ], indirect=['tiny_dataset'])
 def test_dim_axes2(tiny_dataset, expected):
     assert tiny_dataset.dim_axes() == expected
+
+
+# Tests for all dimensions - may differ between datasets.
+@mark.parametrize('tiny_dataset, expected', [
+    ('gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
+    ('downscaled', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
+    ('hydromodel_gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),  # why isn't depth in this list?
+    ('climo_gcm', {'T': 'time', 'X': 'lon', 'Y': 'lat'}),
+], indirect=['tiny_dataset'])
+def test_axes_dim(tiny_dataset, expected):
+    assert tiny_dataset.axes_dim() == expected
 
 
 @mark.parametrize('tiny_dataset, expected', [


### PR DESCRIPTION
modelmeta indexing script uses several additional methods that belong in `nchelpers`.

During work on the indexing script, I discovered that the apparent intended outputs of the methods `dim_axes_from_names` and `dim_axes` had been modified undesirably in the initial version of nchelpers: Original/desired output is dict mapping dimension names to axis names, i.e., {dim: axis}. Initial version of nchelpers had output {axis: dim}.The apparent original intention is more convenient for coding the indexing script, so I restored it, updated tests for those 2 methods, and updated (internal) clients of those methods. There are no external clients at present, so this is only technically a breaking change.

@jameshiebert let's discuss if you have concerns about these changes.

Note: There are other functions in the new Python indexing script that should probably be migrated to nchelpers, but that may be subject to discussion. No need to merge this PR until discussion and modifications have been completed.