### PR TITLE
Make time_resolution work on climo datasets

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -467,10 +467,10 @@ class CFDataset(Dataset):
             return {
                 12: 'monthly',
                 4: 'seasonal',
-                1: 'annual',
-                5: 'seasonal,annual',
-                13: 'monthly,annual',
-                17: 'monthly,seasonal,annual',
+                1: 'yearly',
+                5: 'seasonal,yearly',
+                13: 'monthly,yearly',
+                17: 'monthly,seasonal,yearly',
             }.get(self.time_var.size, 'other')
         return resolution_standard_name(self.time_step_size)
 

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -469,6 +469,7 @@ class CFDataset(Dataset):
                 4: 'seasonal',
                 1: 'annual',
                 5: 'seasonal,annual',
+                13: 'monthly,annual',
                 17: 'monthly,seasonal,annual',
             }.get(self.time_var.size, 'other')
         return resolution_standard_name(self.time_step_size)

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -463,8 +463,14 @@ class CFDataset(Dataset):
     @property
     def time_resolution(self):
         """A standard string that describes the time resolution of the file"""
-        # if self.is_multi_year_mean:
-        #    return 'other'
+        if self.is_multi_year_mean:
+            return {
+                12: 'monthly',
+                4: 'seasonal',
+                1: 'annual',
+                5: 'seasonal,annual',
+                17: 'monthly,seasonal,annual',
+            }.get(self.time_var.size, 'other')
         return resolution_standard_name(self.time_step_size)
 
     def var_bounds_and_values(self, var_name, bounds_var_name=None):

--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -24,7 +24,7 @@ def resolution_standard_name(seconds):
         return 'seasonal'
     for d in [360, 365, 366]:
         if seconds == time_to_seconds(d, 'days'):
-            return 'annual'
+            return 'yearly'
     return 'other'
 
 

--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -4,23 +4,28 @@ import collections
 
 def resolution_standard_name(seconds):
     '''Return a standard descriptive string given a time resolution in seconds'''
-    return {
-        60: '1-minute',
-        120: '2-minute',
-        300: '5-minute',
-        900: '15-minute',
-        1800: '30-minute',
-        3600: '1-hourly',
-        10800: '3-hourly',
-        21600: '6-hourly',
-        43200: '12-hourly',
-        86400: 'daily',
-        2678400: 'monthly',
-        2635200: 'monthly',
-        2592000: 'monthly',
-        31536000: 'yearly',
-        31104000: 'yearly',
-    }.get(seconds, 'other')
+    for m in [1, 2, 5, 15, 30]:
+        if seconds == time_to_seconds(m, 'minutes'):
+            return '{}-minute'.format(m)
+    for h in [1, 3, 6, 12]:
+        if seconds == time_to_seconds(h, 'hours'):
+            return '{}-hourly'.format(h)
+    if seconds == time_to_seconds(1, 'days'):
+        return 'daily'
+    # A month can have between 28 and 31 days in it, depending on calendar and leap-yearness.
+    # To simplify processing of median values, allow any value between these limits even though the actual
+    # possible set is relatively small (but hard to precompute).
+    if time_to_seconds(28, 'days') <= seconds <= time_to_seconds(31, 'days'):
+        return 'monthly'
+    # A season can have between 88 and 92 days in it, depending on calendar and leap-yearness.
+    # To simplify processing of median values, allow any value between these limits even though the actual
+    # possible set is relatively small (but hard to precompute).
+    if time_to_seconds(88, 'days') <= seconds <= time_to_seconds(92, 'days'):
+        return 'seasonal'
+    for d in [360, 365, 366]:
+        if seconds == time_to_seconds(d, 'days'):
+            return 'annual'
+    return 'other'
 
 
 def time_to_seconds(x, units='seconds'):

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -87,12 +87,11 @@ from nchelpers.date_utils import time_to_seconds
     #   time_range
     #   time_range_formatted
     #   time_step_size
-    #   time_resolution
     ('climo_gcm', 'first_MiB_md5sum', 'b9ce45acbefae185fbbc4028e57e6758'),
     ('climo_gcm', 'md5', 'b9ce45acbefae185fbbc4028e57e6758'),
     ('climo_gcm', 'climatology_bounds_var_name', 'climatology_bnds'),
     ('climo_gcm', 'is_multi_year_mean', True),
-    ('climo_gcm', 'time_resolution', 'monthly'), # not that this is very meaningful for a climo file
+    ('climo_gcm', 'time_resolution', 'monthly,seasonal,annual'),
     ('climo_gcm', 'is_unprocessed_gcm_output', True), # actually so, though the term 'unprocessed' here is misleading
     ('climo_gcm', 'is_downscaled_output', False),
     ('climo_gcm', 'is_hydromodel_output', False),

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -91,7 +91,7 @@ from nchelpers.date_utils import time_to_seconds
     ('climo_gcm', 'md5', 'b9ce45acbefae185fbbc4028e57e6758'),
     ('climo_gcm', 'climatology_bounds_var_name', 'climatology_bnds'),
     ('climo_gcm', 'is_multi_year_mean', True),
-    ('climo_gcm', 'time_resolution', 'monthly,seasonal,annual'),
+    ('climo_gcm', 'time_resolution', 'monthly,seasonal,yearly'),
     ('climo_gcm', 'is_unprocessed_gcm_output', True), # actually so, though the term 'unprocessed' here is misleading
     ('climo_gcm', 'is_downscaled_output', False),
     ('climo_gcm', 'is_hydromodel_output', False),


### PR DESCRIPTION
Fixes https://github.com/pacificclimate/modelmeta/issues/9

This covers climo (multi-year mean) datasets in two ways: MYM datasets are handled explicitly in `CFDatasets.time_resolution`, and `date_utils.resolution_standard_name` also handles values that can come from MYM datasets properly. Slight overkill, but `resolution_standard_name` was a bit murky and limited before, now it's not.