### PR TITLE
Raise more helpful exceptions when attributes are missing

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -437,11 +437,10 @@ class CFDataset(Dataset):
             if name in self.variables:
                 return name
 
-        def multi_year_bounds(time_bounds):
+        def multi_year_bounds(time_bounds, scale):
             """Return True iff time bounds is non-empty and each time bound spans at least 2 years.
             Note: 2 years is small, but test code uses relatively short multi-year means.
             """
-            scale = time_scale(time_bounds)
             return time_bounds.size > 0 and all(
                 time_to_seconds(end_time, scale) - time_to_seconds(start_time, scale) >= time_to_seconds(720, 'days')
                 for start_time, end_time in time_bounds[:]
@@ -450,17 +449,19 @@ class CFDataset(Dataset):
         # Heuristic: Time variable has 'bounds' (not 'climatology') attribute identifying an existing variable
         # AND that time bounds variable brackets multi-year periods (corresponding to the climatological averaging)
         if hasattr(time_var, 'bounds'):
+            scale = time_scale(time_var)
             time_bounds_name = time_var.bounds
             time_bounds = self.variables[time_bounds_name]
-            if multi_year_bounds(time_bounds):
+            if multi_year_bounds(time_bounds, scale):
                 return time_bounds_name
 
         # Heuristic: Variable with name 'time_bounds' or 'time_bnds' exists (but not identified by time:bounds)
         # AND that time bounds variable brackets multi-year periods (corresponding to the climatological averaging)
         for time_bounds_name in ['time_bounds', 'time_bnds']:
+            scale = time_scale(time_var)
             if time_bounds_name in self.variables:
                 time_bounds = self.variables[time_bounds_name]
-                if multi_year_bounds(time_bounds):
+                if multi_year_bounds(time_bounds, scale):
                     return time_bounds_name
 
         # Alas

--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -2,13 +2,20 @@ from datetime import datetime, date
 import collections
 import re
 
+from nchelpers.exceptions import CFAttributeError, CFValueError
+
 
 def time_scale(time_var):
-    match = re.match('(days|hours|minutes|seconds) since.*', time_var.units)
+    try:
+        units = time_var.units
+    except AttributeError:
+        raise CFAttributeError("Time variable '{}' lacks 'units' attribute"
+                               .format(time_var.name))
+    match = re.match('(days|hours|minutes|seconds) since.*', units)
     if match:
         return match.groups()[0]
     else:
-        raise ValueError("cf_units param must be a string of the form '<time units> since <reference time>'")
+        raise CFValueError("cf_units param must be a string of the form '<time units> since <reference time>'")
 
 
 def resolution_standard_name(seconds):
@@ -48,7 +55,7 @@ def time_to_seconds(x, units='seconds'):
     if units in seconds_per_unit:
         return x * seconds_per_unit[units]
     else:
-        raise ValueError("No conversions available for unit '{}'".format(units))
+        raise CFValueError("No conversions available for unit '{}'".format(units))
 
 
 def to_datetime(value):

--- a/nchelpers/exceptions.py
+++ b/nchelpers/exceptions.py
@@ -1,0 +1,17 @@
+"""Exceptions explicitly raised by this package.
+
+Following best practice, all raised exceptions are derived from a single
+package-specific base class so that 'all exceptions raised by nchelpers`
+can be caught if desired.
+"""
+
+class CFException(Exception):
+    pass
+
+
+class CFAttributeError(CFException):
+    pass
+
+
+class CFValueError(CFException):
+    pass


### PR DESCRIPTION
Fixes #24 

Also sneaking in a fix for `climatology_bounds_var_name`, which tried to get time units (attribute) from the time bounds variable, and failed in this unhelpful way because, generally speaking, units are on the time variable proper, not the bounds variable.