### PR TITLE
Don't count grid mapping variables as dependent variables

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -917,6 +917,8 @@ class CFDataset(Dataset):
                 non_dependent_var_names.add(variable.bounds)
             if hasattr(variable, 'climatology'):
                 non_dependent_var_names.add(variable.climatology)
+            if hasattr(variable, 'grid_mapping'):
+                non_dependent_var_names.add(variable.grid_mapping)
             if hasattr(variable, 'coordinates'):
                 non_dependent_var_names.update(variable.coordinates.split())
         return [name for name in var_names - non_dependent_var_names]


### PR DESCRIPTION
Adds handling for netCDF files like this:
```
	float pr(time, lat, lon) ;
		pr:_FillValue = -9999.f ;
		pr:grid_mapping = "crs" ;
		pr:long_name = "Monthly total precipitation" ;
		pr:long_description = "Climatological aided interpolation of monthly total precipitation." ;
		pr:standard_name = "lwe_thickness_of_precipitation_amount_anomaly" ;
		pr:units = "mm" ;
		pr:cell_methods = "time: sum within months" ;
	int crs ;
		crs:grid_mapping_name = "latitude_longitude" ;
		crs:long_name = "CRS definition" ;
		crs:longitude_of_prime_meridian = 0. ;
		crs:semi_major_axis = 6378137. ;
		crs:inverse_flattening = 298.257222101 ;
		crs:spatial_ref = "GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]]" ;
		crs:GeoTransform = "-140.0041666666665 0.008333333332999999 0 61.9958333333325 0 -0.008333333332999999 " ;
```

where one variable (`pr`) lists the name of another variable (`crs`) as the value of its `grid_mapping` attribute. Removes the variable describing the grid mapping from the list of "important" dependent variables to be indexed or manipulated.