### PR TITLE
Add support for datasets with no time axis

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -68,7 +68,8 @@ standard_tres_to_mip_table = {
     'daily': 'day',  # MIP table and frequency standard
     'monthly': 'mon',  # frequency std
     'yearly': 'yr',  # frequency std
-    'fx': 'fx' # time-independent data
+    'fx': 'fx', # time-independent data
+    'fixed': 'fx'
 }
 
 
@@ -1048,9 +1049,18 @@ class CFDataset(Dataset):
 
     ###########################################################################
     # Variables - time
-    # These functions will throw an error if used on netCDF files with no time
-    # axis. Whether a file has a time axis can be checked with is_time_invariant.
-
+    # It is up to the caller of nchelpers functions to check is_time_invariant
+    # and to not call time-related accessor functions on a dataset with no time
+    # axis. The following accessors will throw a CFValueError "No axis is
+    # attributed with time information" when called on a time-invariant dataset:
+    # * time_var
+    # * time_var_values
+    # * time_steps
+    # * time_step_size
+    # * time_range
+    # * time_range_as_dates
+    # 
+    # time_resolution returns a resolution of "fixed" for time-invariant datasets.
     @property
     def time_var(self):
         """The time variable (netCDF4.Variable) in this file"""
@@ -1104,7 +1114,7 @@ class CFDataset(Dataset):
                 17: 'monthly,seasonal,yearly',
             }.get(self.time_var.size, 'other')
         if self.is_time_invariant:
-            return "invariant"
+            return "fixed"
         return resolution_standard_name(self.time_step_size)
 
     @cached_property

--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -22,6 +22,8 @@ def time_scale(time_var):
 def resolution_standard_name(seconds):
     """Return a standard descriptive string given a time resolution in seconds.
     """
+    if seconds is None:
+        return "invariant"
     for m in [1, 2, 5, 15, 30]:
         if seconds == time_to_seconds(m, 'minutes'):
             return '{}-minute'.format(m)

--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -22,8 +22,6 @@ def time_scale(time_var):
 def resolution_standard_name(seconds):
     """Return a standard descriptive string given a time resolution in seconds.
     """
-    if seconds is None:
-        return "invariant"
     for m in [1, 2, 5, 15, 30]:
         if seconds == time_to_seconds(m, 'minutes'):
             return '{}-minute'.format(m)


### PR DESCRIPTION
This PR adds support for gridded datasets with no time axis, such as data describing static elevation or soil information.

It adds a new property, `is_time_invariant` to `CFDataset`. A dataset will be recognized as time-invariant if it lacks a recognizable time dimension _and_ has the metadata `frequency` attribute set to the CF-Standard `fx` (fixed). The reasoning is that accidentally removing a time dimension could plausibly be a mistake, but the presence of the metadata attribute indicates actual intent to make a time-invariant dataset.

It is up to the caller of `nchelpers` functions to check `is_time_invariant` and to not call time-related accessor functions on a dataset with no time axis. The following accessors will throw an error (`CFValueError("No axis is attributed with time information")`) when called on a dataset with no time axis:
* `time_var`
* `time_var_values`
* `time_steps`
* `time_step_size`
* `time_range`
* `time_range_as_dates`

The following time-related function does _not_ throw an error:
* `time_resolution` returns a resolution of "invariant"

Resolves #62 