### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,32 @@
+@Library('pcic-pipeline-library')_
+
+
+node {
+    stage('Code Collection') {
+        collectCode()
+    }
+
+    stage('Testing') {
+        def requirements = ['requirements.txt']
+        def pytestArgs = '-v tests'
+        def options =  [aptPackages: ['libhdf5-serial-dev', 'libnetcdf-dev']]
+
+        parallel "Python 3.6": {
+            runPythonTestSuite('crmprtd-python36', requirements, pytestArgs)
+        },
+        "Python 3.7": {
+            runPythonTestSuite('crmprtd-python37', requirements, pytestArgs,
+                               options)
+        }
+    }
+
+    if (isPypiPublishable()) {
+        stage('Push to PYPI') {
+            publishPythonPackage('crmprtd-python36', 'PCIC_PYPI_CREDS')
+        }
+    }
+
+    stage('Clean Workspace') {
+        cleanWs()
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,20 +9,22 @@ node {
     stage('Testing') {
         def requirements = ['requirements.txt']
         def pytestArgs = '-v tests'
-        def options =  [aptPackages: ['libhdf5-serial-dev', 'libnetcdf-dev']]
+        def options = [
+            aptPackages: ['libhdf5-serial-dev', 'libnetcdf-dev', 'git']
+        ]
 
         parallel "Python 3.6": {
-            runPythonTestSuite('crmprtd-python36', requirements, pytestArgs)
+            runPythonTestSuite('python:3.6', requirements, pytestArgs)
         },
         "Python 3.7": {
-            runPythonTestSuite('crmprtd-python37', requirements, pytestArgs,
+            runPythonTestSuite('python:3.7', requirements, pytestArgs,
                                options)
         }
     }
 
     if (isPypiPublishable()) {
         stage('Push to PYPI') {
-            publishPythonPackage('crmprtd-python36', 'PCIC_PYPI_CREDS')
+            publishPythonPackage('python:3.6', 'PCIC_PYPI_CREDS')
         }
     }
 


### PR DESCRIPTION
This PR adds a `Jenkinsfile` to control a Jenkins Pipeline.  The pipeline runs the test suite in both python `3.6` and `3.7`.  Furthermore, it will release a package on `pypi` if `git tags` are detected on master.