### PR TITLE
Upgrade netCDF4 in requirements

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -262,6 +262,7 @@ class CFDataset(Dataset):
         both strict and non-strict behaviours.
         """
         super(CFDataset, self).__init__(*args, **kwargs)
+        self.set_auto_mask(False)
         # Store options directly via dict to prevent them being treated as
         # Dataset attributes.
         # It's possible that it would be better to define ``__setattribute__``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil
-netCDF4==1.3
+netCDF4==1.5.*
 cached-property
 pytest

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Rod Glover",
     author_email="rglover@uvic.ca",
     zip_safe=True,
-    install_requires=['netCDF4==1.3', 'cached-property', 'python-dateutil'],
+    install_requires=['netCDF4', 'cached-property', 'python-dateutil'],
     package_data={'nchelpers': [
         'data/CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc',
         'data/cgcm.nc',


### PR DESCRIPTION
This PR upgrades the version of netCDF4 in `requirements.txt` to 1.5, while simultaneously removing the version requirement in `setup.py` (to follow our best practices).

With nearly 90% test coverage, all of the tests pass, so I think that it's a *relatively* safe change.
