### PR TITLE
Return variables with _FillValues as masked arrays in CFDataset

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -262,7 +262,19 @@ class CFDataset(Dataset):
         both strict and non-strict behaviours.
         """
         super(CFDataset, self).__init__(*args, **kwargs)
-        self.set_auto_mask(False)
+        # netcdf4 version 1.5 changed the default behaviour of variables.
+        # In v 1.4, variables that had any value equal to _FillValue or
+        # missing_value were converted into numpy masked arrays with such values
+        # masked; variables without any such values became regular numpy arrays.
+        #
+        # In contrast, netCDF4 version 1.5 by default converts all variables to
+        # masked arrays. We don't want that behaviour, we've written a lot of code
+        # assuming things like latitude are simple non-masked numpy arrays.
+        self.set_auto_mask(True) # DO return variables with fill values 
+                                 # as masked arrays
+        self.set_always_mask(False) # DO NOT return variables without 
+                                    # fill values as masked arrats.
+        
         # Store options directly via dict to prevent them being treated as
         # Dataset attributes.
         # It's possible that it would be better to define ``__setattribute__``

--- a/tests/test_CFDataset.py
+++ b/tests/test_CFDataset.py
@@ -742,6 +742,7 @@ def test_get_var_bounds_and_values(tiny_dataset, var_name):
     ('gcm', 'lon', (264.375, 272.8125)),
     ('gcm', 'lat', (65.5776, 73.9475)),
     ('gcm', 'tasmax', (220.68445, 304.13501)),
+    ('hydromodel_gcm', 'BASEFLOW', (0.44171903, 3.790513)),
 ], indirect=['tiny_dataset'])
 def test_variable_range(tiny_dataset, var_name, expected):
     assert tiny_dataset.var_range(var_name, chunksize=2) == approx(expected)


### PR DESCRIPTION
Resolves #79 

netCDF4 1.4 had the following behaviour:

- if a netCDF variable has a fill value or missing value defined as an attribute, and the specified value is present in the variable, return data from the variable as a masked numpy array
- otherwise return a normal numpy array

netCDF4 1.5 has the following behaviour:
- return data from all variables as masked numpy arrays

The new behaviour in 1.5 broke some of our code, which wasn't expecting "dimensional" variables like latitude, longitude, and time to be masked arrays. Therefore, we want to restore the netCDF 1.4 behaviour, which can be done via the somewhat confusing `set_always_mask` and `set_auto_mask` flags on a variable or dataset. 

| set_always_mask value | set_auto_mask value | behaviour                                                                                                             |
|-----------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------|
| True                  | True                | all variables are masked arrays                                                                                       |
| True                  | False               | all variables are unmasked arrays (?!) Honestly not sure what *should* happen here, the flags seem contradictory. Maybe an error message would be a good idea?                                                                               |
| False                 | True                | variables with `_FillValue` or `missing_value` present in the data are masked arrays, other variables are unmasked arrays |
| False                 | False               | all variables are unmasked arrays                                                                                     |

This PR sets what I think are the flags we want: `set_always_mask` False, and `set_auto_mask` True, and adds a test of the `var_range()` function on a file with some `_FillValue`s, to help catch future fill value weirdness.

Before merging, I'd like to test this version against the PCEX backend and modelmeta.