### PR TITLE
Increase netCDF4 version to >= 1.5.4

### DIFF
--- a/nchelpers/date_utils.py
+++ b/nchelpers/date_utils.py
@@ -162,12 +162,12 @@ def truncate_to_resolution(date, resolution):
     dates will be truncated to December 1 of the *previous* year,
     reflecting that winter crosses the year boundary."""
     if 'minute' in resolution:
-        n = re.match('^(\d+)-minute$',resolution)
+        n = re.match(r'^(\d+)-minute$',resolution)
         if n and int(n.group(1)) in [1, 2, 5, 15, 30]:
             return datetime(date.year, date.month, date.day, date.hour,
                             date.minute - (date.minute % int(n.group(1))))
     elif 'hourly' in resolution:
-        n = re.match('^(\d+)-hourly$',resolution)
+        n = re.match(r'^(\d+)-hourly$',resolution)
         if n and int(n.group(1)) in [1, 3, 6, 12]:
             return datetime(date.year, date.month, date.day,
                             date.hour - (date.hour % int(n.group(1))))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil
-netCDF4==1.5.*
+netCDF4>=1.5.4
 cached-property
 pytest


### PR DESCRIPTION
Any versions of the `netCDF4` library < 1.5.4 are causing a large number of warnings in `thunderbird` (and probably others) because of the [deprecation of `numpy`'s `tostring()` method](https://github.com/Unidata/netcdf4-python/blob/bcbe3a0c62e6aa012b7afe7c9b2cfc9b2abc5424/Changelog#L28)