### PR TITLE
Bump to version 5.5.8 and update NEWS

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,6 @@
 News / Release Notes
 ====================
-5.5.7
+5.5.8
 ------
 *Release Date: 25-Sep-2021*
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = (5, 5, 7)
+__version__ = (5, 5, 8)
 
 setup(
     name="nchelpers",


### PR DESCRIPTION
A tag for 5.5.7 already existed, so going to the next patch release.