### PR TITLE
Remove spammy debug output

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -510,7 +510,6 @@ class CFDataset(Dataset):
             metadata standard (CMIP3, CMIP5, CMIP6, non-GCM)
             this dataset is using. Usually this is the project_id
             attribute, but for CMIP6, it is the mip_era attribute"""
-            print("inside get metadata standard")
             try:
                 project_id = self.dataset.project_id
                 if project_id in ["CMIP3", "CMIP5", "other"]:


### PR DESCRIPTION
Removes a print statement I added to help me debug during a previous upgrade. I missed the statement during cleanup, and it's really spammy; makes it hard to see actual status output during indexing.

I don't think we need a code review for this. 

Resolves #90 