### PR TITLE
parse daily climatologies

### DIFF
--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -725,7 +725,7 @@ class CFDataset(Dataset):
         # Additional non-strict heuristics begin here
 
         # Heuristic: Time variable has "suspicious" length:
-        # 1, 4, 12, 5, 13, 16, 17 (yearly, seasonal, monthly, and
+        # 1, 4, 12, 365, 5, 13, 16, 17 (yearly, seasonal, monthly, daily, and
         # various concatenations thereof)
         # AND time variable has likely values (mid-month, mid-season, mid-year)
 
@@ -744,12 +744,17 @@ class CFDataset(Dataset):
         def check_yearly(time_steps):
             t = next(time_steps)
             return (t.month == 6 and t.day == 30) or (t.month == 7 and t.day in {1, 2})
+            
+        def check_daily(time_steps):
+            t = next(time_steps)
+            return (t.month == 1 and t.day == 1)
 
         try:
             check_intervals = {
                 1: (check_yearly,),
                 4: (check_seasonal,),
                 12: (check_monthly,),
+                365: (check_daily,),
                 5: (check_seasonal, check_yearly),
                 13: (check_monthly, check_yearly),
                 16: (check_monthly, check_seasonal),
@@ -1178,6 +1183,7 @@ class CFDataset(Dataset):
                 5: "seasonal,yearly",
                 13: "monthly,yearly",
                 17: "monthly,seasonal,yearly",
+                365: "daily"
             }.get(self.time_var.size, "other")
         if self.is_time_invariant:
             return "fixed"

--- a/nchelpers/__init__.py
+++ b/nchelpers/__init__.py
@@ -725,8 +725,8 @@ class CFDataset(Dataset):
         # Additional non-strict heuristics begin here
 
         # Heuristic: Time variable has "suspicious" length:
-        # 1, 4, 12, 365, 5, 13, 16, 17 (yearly, seasonal, monthly, daily, and
-        # various concatenations thereof)
+        # 1, 4, 12, 365, 360, 5, 13, 16, 17 (yearly, seasonal, monthly, daily, 
+        # daily with a 360 day calendar, and various concatenations thereof)
         # AND time variable has likely values (mid-month, mid-season, mid-year)
 
         def check_monthly(time_steps):
@@ -755,6 +755,7 @@ class CFDataset(Dataset):
                 4: (check_seasonal,),
                 12: (check_monthly,),
                 365: (check_daily,),
+                360: (check_daily,),
                 5: (check_seasonal, check_yearly),
                 13: (check_monthly, check_yearly),
                 16: (check_monthly, check_seasonal),
@@ -1183,7 +1184,8 @@ class CFDataset(Dataset):
                 5: "seasonal,yearly",
                 13: "monthly,yearly",
                 17: "monthly,seasonal,yearly",
-                365: "daily"
+                360: "daily",
+                365: "daily",
             }.get(self.time_var.size, "other")
         if self.is_time_invariant:
             return "fixed"


### PR DESCRIPTION
This branch adds support for daily climatologies to the code that determines what the time resolution of a climatology is, used by the indexer in modelmeta. Previously we've supported non-climatological daily datasets, but not daily climatologies. Changes are fairly minor.

Resolves #93 